### PR TITLE
CHOPIN-48501: Reworked get_security_annotations script and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,11 +534,7 @@ def start():
             log_event_attributes(event)
 ```
 
-> The `ApiClient` class is available in the `api_client.py` file. It helps you with authorization when accessing 
-> the API. It also implements `CollectionIterator` class which is `iterable` and which helps you to traverse through all the
-> pages of each individual collection. Use `create_collection_iterator` method on `ApiClient` instance to create 
-> `CollectionIterator` instance - it passes to it configured "self" (ApiClient) instance directly.
-> In the real world usage, you also need to provide the valid SecureX API host name and client credentials as `ApiClient` arguments.
+> The `ApiClient` class is available in the `api_client.py` file. It includes authorization and also implements iterable `CollectionIterator` class, that allows traversal through all the pages of each individual collection. Use `create_collection_iterator` method on `ApiClient` instance to create a `CollectionIterator` instance that includes a configured `ApiClient` (`self`). In the real world usage, you also need to provide a valid SecureX API host name and client credentials as `ApiClient` arguments.
 
 The `log_event_attributes` method represents whatever processing of the `Event` you would like to do, with the access to the parent `ThreatDetection` and its parent `Alert`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Using Global Threat Alerts (formerly Cognitive Intelligence) API
 
-To access global threat alerts API, you need to have enabled integration with Cognitive Threat Response(CTR)/SecureX
+To access global threat alerts API, you need to have enabled integration with Cognitive Threat Response/SecureX
 and valid SecureX API client credentials. You can find information on creating it
-in [Getting API Access Token](https://api.cta.eu.amp.cisco.com/docs/#/authentication) GTA documentation.
+in [Getting API Access Token](https://api.cta.eu.amp.cisco.com/docs/#/authentication) global threat alerts documentation.
 Specifically you'll need:
 * Client ID (`SECUREX_CLIENT_ID`)
 * Client Password (`SECUREX_CLIENT_PASSWORD`)
@@ -22,18 +22,28 @@ $ curl -X POST \
      -H 'Content-Type: application/x-www-form-urlencoded' \
      -H 'Accept: application/json' \
      -d 'grant_type=client_credentials' \
-     'https://${SECUREX_VISIBILITY_HOST_NAME}/iroh/oauth2/token'
+  "https://${SECUREX_VISIBILITY_HOST_NAME}/iroh/oauth2/token"
 ```
 
-You'll get the token response:
+You'll get the token response (200 OK):
 ```json
 {
-    "access_token": "ey..example..Eg",
+    "access_token": "ey..this.is.very.long.in.reality.....example..Eg",
     "token_type": "bearer",
     "expires_in": 600,
     "scope": "casebook"
 }
 ```
+In case something went wrong you'll get "400 Bad Request" with explanation in "error_description",
+e.g. for invalid client ID:
+```json
+{
+    "error": "invalid_client",
+    "error_description": "unknown client",
+    "error_uri": "https://tools.ietf.org/html/rfc6749#section-5.2"
+}
+```
+
 To construct authorization header (in form `Authorization: <type> <credentials>`) you need to combine information
 from `token_type` and `access_token`. We do translate `"token_type": "bearer"` to type `Bearer` and use `access_token`
 value as credentials.
@@ -50,7 +60,7 @@ Use the `/alerts` resource to get `Alerts`:
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts"
 ```
 
 You'll get a paginated collection response:
@@ -76,43 +86,43 @@ You can learn more about [how the pagination works](#pagination) or see our exam
 
 ## Synchronize Alerts
 
-### Get new Alerts triggered since the last synchronization
+### Get new Alerts triggered after the last synchronization
 
-For initial synchronization of `Alerts`, use the `/alerts` resource with `sort=triggeredAt:asc` parameter, eg:
+For initial synchronization of `Alerts`, use the `/alerts` resource with `sort=triggeredAt:asc` parameter:
 
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?sort=triggeredAt:asc
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?sort=triggeredAt:asc"
 ```
 
 To get only newly created `Alerts` in subsequent synchronizations:
 
 1. take `triggeredAt` of last `Alert` from previous request (it's the latest because of `sort=triggeredAt:asc`)
-1. use it for new request as a `triggeredSince` parameter
+1. use it for new request as a `triggeredAfter` parameter
 
-Eg:
-
-```console
-$ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-       -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?triggeredSince=2020-09-05T12:00:00Z&sort=triggeredAt:asc
-```
-
-See [Date-time format](#date-time-format) for more information about `triggeredSince` format.
-
-### Get modified (and new) Alerts since a specific point in time
-
-Use the `/alerts` resource with `modifiedSince=[date-time]` parameter, eg:
+Example:
 
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?modifiedSince=2020-09-05T12:00:00Z
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?triggeredAfter=2020-09-05T12:00:00Z&sort=triggeredAt:asc"
 ```
-You'll get all `Alerts` with `Alert.modifiedAt` value greater than value requested in `modifiedSince` parameter.
 
-See [Date-time format](#date-time-format) for more information about `modifiedSince` format.
+See [Date-time format](#date-time-format) for more information about `triggeredAfter` format.
+
+### Get modified (and new) Alerts after a specific point in time
+
+Use the `/alerts` resource with `modifiedAfter=[date-time]` parameter:
+
+```console
+$ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+       -H "Accept: application/json" \
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?modifiedAfter=2024-09-05T12:00:00Z"
+```
+You'll get all `Alerts` with `Alert.modifiedAt` value greater than value requested in `modifiedAfter` parameter.
+
+See [Date-time format](#date-time-format) for more information about `modifiedAfter` format.
 
 `Alert.modifiedAt` is initially the same as `Alert.triggeredAt` but changes when:
 
@@ -137,7 +147,7 @@ To get one Alert with a known `id`, use:
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}"
 ```
 
 ## Update Alert state
@@ -150,7 +160,7 @@ $ curl -X PATCH \
        -H "Accept: application/json" \
        -H "Content-Type: application/json" \
        --data '{"state":"Remediated"}' \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}/state
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}/state"
 ```
 
 Available `AlertState` values:
@@ -174,7 +184,7 @@ $ curl -X PATCH \
        -H "Accept: application/json" \
        -H "Content-Type: application/json" \
        --data '{"note":"Started investigation, our internal ticket ID=XXXXXX"}' \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}/note
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts/${ALERT_ID}/note"
 ```
 
 _**Caution:** When the alert is in the New state, the note may get deleted when alerts are recalculated. To prevent this, change the state of the alert to not New._
@@ -183,7 +193,7 @@ _**Caution:** When the alert is in the New state, the note may get deleted when 
 
 ## Date-time format
 
-For parameters like `triggeredSince`, `modifiedSince`, etc. use ISO 8601 date-time format as defined by [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
+For parameters like `triggeredAfter`, `modifiedAfter`, etc. use ISO 8601 date-time format as defined by [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6).
 
 Same format is also used for all date-time information in API responses.
 
@@ -253,10 +263,10 @@ Fields:
 
 * `previous`
   * a relative path to the previous page
-  * if the previous page does not exist, `null` is returned
+  * if the previous page does not exist or request method is POST, `null` is returned
 * `next`
   * a relative path to the next page
-  * if the next page does not exist, `null` is returned.
+  * if the next page does not exist or request method is POST, `null` is returned.
 * `hasPreviousPage` 
   * boolean value about the previous page existence
   * `true` means the previous page is available
@@ -265,11 +275,11 @@ Fields:
   * `true` means the next page is available
 * `startCursor`
   * value identifies the first item in the current results
-  * should be used to construct a request for the previous page
+  * should be used to construct a request for the previous page. Necessary when requesting collection resources with parameters using POST method. 
   * when the previous page is not available, `null` is returned
 * `endCursor`
   * value identifies the last item in the current results
-  * should be used to construct a request for the next page
+  * should be used to construct a request for the next page. Necessary when requesting collection resources with parameters using POST method.
   * when the next page is not available, `null` is returned
 
 ### Limiting results
@@ -285,20 +295,20 @@ Example:
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?size=10
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/${CUSTOMER_ID}/alerts?size=10"
 ```
 
 ### Getting the next page
 
-To get the next page of previous response, use `after=[endCursor]` query parameter in your next request, eg:
+To get the next page of previous response, use `after=[endCursor]` query parameter in your next request:
 
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/alert-management/customer/CTA123456789/alerts?size=10&after=32c43ccb-20b7-4e39-a2ab-d05791ae23f0
+  "https://api.cta.eu.amp.cisco.com/alert-management/customer/CTA123456789/alerts?size=10&after=32c43ccb-20b7-4e39-a2ab-d05791ae23f0"
 ```
 
-> You can also use the `next` link from the `pageInfo`.
+> You can also use the `next` link from the `pageInfo` if available.
 
 > The similar situation is when you'd like to get `previous` page. You just need to use `before=[startCursor]` as parameter.
 
@@ -347,7 +357,7 @@ def get_all_alerts():
 print(get_all_alerts())
 ```
 
-> This script is available in the `get_all_alerts.py` file.
+> This script improved by direct usage of SecureX credential is available in the `get_all_alerts.py` file. 
 
 ## Synchronizing external SIEM
 
@@ -362,97 +372,193 @@ To get the first page of `ThreatDetections`, use the following query:
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/threat-detection/customer/{CUSTOMER_ID}/threat-detections
+  "https://api.cta.eu.amp.cisco.com/threat-detection/customer/${CUSTOMER_ID}/threat-detections"
 ```
 
-To get the first page of `Events`:
+To get the first page of security `Events`:
 
 ```console
 $ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/event-detection/customer/{CUSTOMER_ID}/events
+  "https://api.cta.eu.amp.cisco.com/event-detection/customer/${CUSTOMER_ID}/events"
 ```
 
-Each convicting `Event` can belong to one or more `ThreatDetections`. This can lead to processing a single convicting `Event` multiple times. However relation to multiple `ThreatDetections` is quite rare.
+### Modification Sequence Number
 
-Most convicting `Events` contain `securityAnnotation`, which represents key observations used for detecting threat or malicious behavior.
+Because there are potentially a lots of `ThreatDetections` and magnitude more `Events` we need to have mechanism
+how to get from API just new or updated items. We usually don't want to deal with e.g., all `Events` again when
+we already processed and synchronized part of them. Previously we introduced time based query parameters,
+especially on `Alert` level but such approach is not suitable here because in one moment lots of objects can be created.
+And yes, we can miss some important ones when relying just on time.
+
+For stable order of items returned in response we implemented `modification sequence number` mechanism.
+`Modification sequence number` is unique increasing number which is internally assigned to all `Events`, `ThreatDetections`
+and `Flows` when they are created or re-assigned when objects are updated. `modification sequence numbers`
+are only available in collection responses in `pageInfo`section for first and last item as `startCursor` and `endCursor` values.
+You only need to query collection with specific sort parameter`sort=modificationSequenceNumber` to get them.
+Such stable order of items in collection ensure we do not miss any important update and we can safely continue where we ended last time.
+
+> Only selected resources support `sort=modificationSequenceNumber`,
+> see Global Threat Alerts [OpenAPI documentation](https://api.cta.eu.amp.cisco.com/docs/) which resources are supported.
+
+See how we can use `sort=modificationSequenceNumber` on `/events/search` resource:
+
+```console
+$ curl -X POST \
+       -d '{"filter": {}}' \
+       -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+       -H "Accept: application/json" \
+       -H "Content-Type: application/json" \
+  "https://api.cta.eu.amp.cisco.com/event-detection/customer/${CUSTOMER_ID}/events/search?sort=modificationSequenceNumber"
+```
+
+The last paged response could be:
+
+```jsonc
+    {
+      "items": [ /* array */ ],
+      "pageInfo": {
+        "previous": null,
+        "next": null,
+        "hasNextPage": false,
+        "hasPreviousPage": true,
+        "startCursor": "25716998",
+        "endCursor": "25717281"
+      }
+    }
+```
+
+When e.g., next day we would like to get just increments, (new and updated) `Events` we need to remember `endCursor`
+value of the response (`25717281`) and repeat the query with `after` query parameter having `endCursor` as value (`after=25717281`):
+
+```console
+$ curl -X POST \
+       -d '{"filter": {}}' \
+       -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+       -H "Accept: application/json" \
+       -H "Content-Type: application/json" \
+  "https://api.cta.eu.amp.cisco.com/event-detection/customer/${CUSTOMER_ID}/events/search?sort=modificationSequenceNumber&after=25717281"
+```
+> See [Getting the next page](#getting-the-next-page) for more details about how to work with `pageInfo` object
 
 ### Iterating over Events hierarchically with an Alert and a ThreatDetection in the context
 
 To put everything together:
 
-1. Iterate over all `Alerts` (as described in previous sections).
-1. For each `Alert`, iterate over all its `ThreatDetections`.
-1. For each `ThreatDetection`, iterate over all its convicting `Events`.
+1. Iterate over all `Events` with `modificationSequenceNumber` stable sort (as described in previous sections) 
+   having reference to parent `ThreatDetections`. There is special resource for this purpose
+   `/threat-detection/customer/${CUSTOMER_ID}/enriched-events-with-threat-detection-ids`.
+1. Get all referred `ThreatDetections` with references to `Alerts`.
+   Use `/alert-management/customer/${CUSTOMER_ID}/enriched-threat-detections-with-alert-ids/search` 
+1. You can get `Alerts` one by one or use bulk resource to get them.
+   E.g., `/alert-management/customer/${CUSTOMER_ID}/alerts/search`
 
-Optionally, to get a better insight, you can also iterate over all contextual `Events` using:
+> `Events` without references to `ThreatDetections` are called "contextual" while `Events` with reference(s) are called "convicting".
 
-```console
-$ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-       -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/threat-detection/customer/{CUSTOMER_ID}/threat-detections/{THERAT_DETECTION_ID}/events/contextual
-```
+#### Example (simplified)
 
-Beware that each contextual `Event` spotted on particular `Asset` belongs to every
-`ThreatDetection` detected on this `Asset`. Therefore it's quite common for one contextual `Event` to belong to several
-`ThreatDetections`. This can lead to processing a single contextual `Event` multiple times.
-
-#### Example
+Following example explains how to traverse objects from bottom to top, from `Events` to `Alerts`. It shows how to use 
+performance optimized resources and for simplification some parts like authorization are omitted.
+Approach described in this example is used in `get_security_annotations.py` file - when you'd like to try it out 
+start with this script file.
 
 ```python
 CUSTOMER_ID = "YOUR_CUSTOMER_ID"
 
-
-def build_alert_threat_detections_url(alert_id):
-    return "/alert-management/customer/" + CUSTOMER_ID + "/alerts/" + alert_id + "/threat-detections"
-
-
-def build_threat_detection_convicting_events_url(threat_detection_id):
-    return "/threat-detection/customer/" + CUSTOMER_ID + "/threat-detections/" + threat_detection_id + "/events/convicting"
-
-
 def start():
-    alerts_iterator = CollectionIterator("/alert-management/customer/" + CUSTOMER_ID + "/alerts")
+    events = []
+    threat_detection_ids = []
+    alert_ids = []
+    cached_context_objects = {}
 
+    # get all Events in stable order ensured by `modificationSequenceNumber` 
+    events_iterator = CollectionIterator(
+        collection_url_path="/threat-detection/customer/" + CUSTOMER_ID + "/enriched-events-with-threat-detection-ids",
+        query_params={
+            "sort": "modificationSequenceNumber",
+        })
+
+    # extract references to threat detections and keep them for final processing
+    while events_iterator.has_next():
+        event = events_iterator.next()
+        events.append(event)
+        threat_detection_ids.extend(event["threatDetectionIds"])
+
+    # bulk load threat detections
+    threat_detections_iterator = CollectionIterator(
+        collection_url_path="/alert-management/customer/" + CUSTOMER_ID + "/enriched-threat-detections-with-alert-ids/search",
+        request_body={
+            "filter": {
+                "threatDetectionIds": list(set(threat_detection_ids))
+            }
+        })
+
+    # extract references to alerts and keep threat detections in cache key=ID, value=OBJECT
+    while threat_detections_iterator.has_next():
+        threat_detection = threat_detections_iterator.next()
+        cached_context_objects[threat_detection["id"]] = threat_detection
+        alert_ids.extend(threat_detection["alertIds"])
+
+    # bulk load alerts
+    alerts_iterator = CollectionIterator(
+        collection_url_path="/alert-management/customer/" + CUSTOMER_ID + "/alerts/search",
+        request_body={
+            "filter": {
+                "alertIds": list(set(alert_ids))
+            }
+        })
+
+    # keep alerts in cache key=ID, value=OBJECT
     while alerts_iterator.has_next():
         alert = alerts_iterator.next()
+        cached_context_objects[alert["id"]] = alert
 
-        threat_detections_iterator = CollectionIterator(build_alert_threat_detections_url(alert["id"]))
-
-        while threat_detections_iterator.has_next():
-            threat_detection = threat_detections_iterator.next()
-
-            events_iterator = CollectionIterator(build_threat_detection_convicting_events_url(threat_detection["id"]))
-
-            while events_iterator.has_next():
-                event = events_iterator.next()
-                process_event(alert, threat_detection, event)
+    # Process
+    for event in events:
+        # get IDs references to threat detections from event (usually one)
+        threat_detection_ids = event["threatDetectionIds"]
+    
+        # process all possible threat detections
+        if len(threat_detection_ids) > 0:
+            # process event with threat detections (called "convicting" security event)
+            for threat_detection_id in threat_detection_ids:
+                # get parent objects to event - threat detections and alert
+                threat_detection_with_alert_ids = cached_context_objects[threat_detection_id]
+    
+                # get IDs references to alerts (usually one)
+                alert_ids = threat_detection_with_alert_ids["alertIds"]
+                for alert_id in alert_ids:
+                    alert = cached_context_objects[alert_id]
+    
+                    # log event with related objects - alert, threat detection
+                    log_event_attributes(event, threat_detection_with_alert_ids, alert)
+        else:
+            # process event without threat detections (called "contextual" security event)
+            log_event_attributes(event)
 ```
 
-> `CollectionIterator` class is available in the `get_security_annotations.py` file. It implements `has_next` and `next` methods to be able to go through all pages of items of each individual collection.
+> `CollectionIterator` class is available in the `api_client.py` file. It implements `has_next` and `next` methods
+> to be able to go through all pages of items of each individual collection.
+> In real usage you also need to provide `authorization_fn` argument - function able to provide on demand authorization header value.
 
-Method `process_event` represents whatever processing of  `Event` you wish to do, with access to the parent `ThreatDetection` and its parent `Alert`.
-
-For simplicity we ignore potential duplicities of convicting `Events`.
+Method `log_event_attributes` represents whatever processing of `Event` you wish to do, with access to the parent `ThreatDetection` and its parent `Alert`.
 
 #### Repeated iterations over Events
 
-To automate the process of working with `Events`, e.g. for importing to SIEM, you usually need to process
-only new or updated `Events`.
+You just need to remember events `endCursor` - available under `events_iterator.end_cursor` in previous script example and use it next time as `cursor` argument when
+constructing `CollectionIterator`:
 
-Each `Event` (and `ThreatDetection`) has two date fields available:
+```python
+    events_iterator = CollectionIterator(
+        collection_url_path="/threat-detection/customer/" + CUSTOMER_ID + "/enriched-events-with-threat-detection-ids",
+        query_params={
+            "sort": "modificationSequenceNumber",
+        },
+        cursor=previous_events_end_cursor
+    )
+```
 
-* `detectedAt` - instant when this entity was created by the classification engine
-* `modifiedAt` - instant when this entity was last updated by the classification engine
-
-Each `Event` and `ThreatDetection` can change over time, so use use `modifiedAt` when interested in all the updates.
-
-When running first synchronization of `Events`, saving `modifiedAt` is important for the next synchronization, especially maximum `modifiedAt` value across all `Events`.
-
-In all subsequent synchronizations, compare each `Event.modifiedAt` with maximum `modifiedAt` from previous
-synchronization to process only new or updated `Events`.
-
-> Because `Event` observables are aggregated, it's not possible to distinguish between old attributes values and new ones. `Event` needs to be processed as a whole.
+> Because `Event` observables are aggregated, it's not possible to distinguish between old attributes values and new ones inside `Event`. `Event` needs to be processed as a whole.
 
 ### Importing Events to Splunk
 
@@ -462,17 +568,16 @@ Working example script is available in the  `get_security_annotations.py` file. 
 
 To get started, modify the example script and provide your:
 
-* `CUSTOMER_ID`
 * valid SecureX credentials - `SECUREX_CLIENT_ID` and `SECUREX_CLIENT_PASSWORD`
 * SecureX visibility host name - `SECUREX_VISIBILITY_HOST_NAME`
-* full path to the file in `PREVIOUS_EVENT_MODIFIED_AT_FILENAME`
+* full path to the file in `EVENTS_END_CURSOR_FILENAME`
 
 The script output is generated in `log_event_attributes` method and it's in JSON format. Use Splunk's pre-defined
 source type `_json` to process output of the script.
 
-After each run, the example script persists maximal `modifiedAt` across all processed `Events`.
+After each run, the example script persists last processed event `endCursor` to file `EVENTS_END_CURSOR_FILENAME`.
 
-To run full processing again, delete the file specified in the `PREVIOUS_EVENT_MODIFIED_AT_FILENAME` variable.
+To run full processing again, delete the file specified in the `EVENTS_END_CURSOR_FILENAME` variable.
 
 > The example script only returns specifically selected fields from each object but can be modified to determine which fields to export.
 
@@ -481,14 +586,18 @@ To run full processing again, delete the file specified in the `PREVIOUS_EVENT_M
 In case you need even more granular data, you can also iterate over `Flows` resource:
 
 ```console
-$ curl -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+$ curl -X POST
+       -d '{"filter": {}}'
+       -H "Authorization: Bearer ${ACCESS_TOKEN}" \
        -H "Accept: application/json" \
-  https://api.cta.eu.amp.cisco.com/event-detection/customer/{CUSTOMER_ID}/events/{EVENT_ID}/flows
+  "https://api.cta.eu.amp.cisco.com/event-detection/customer/${CUSTOMER_ID}/flows/search?sort=modificationSequenceNumber"
 ```
 
 `Flow` is immutable and its' `timeStamp` field indicates when it was observed in the network.
+`Flows` also support modification sequence number stable sort.
 
-> Beware that there could be a magnitude more of `Flows` than `Events`. To get the best value out of Global Threat Alerts, it's usually better to work with `Alerts`, `ThreatDetections` and `Events` first.
+> Beware that there could be a magnitude more of `Flows` than `Events`.
+> To get the best value out of Global Threat Alerts, it's usually better to work with `Alerts`, `ThreatDetections` and `Events` first.
 
 ## References
 

--- a/api_client.py
+++ b/api_client.py
@@ -1,4 +1,5 @@
 import requests
+from requests.auth import AuthBase
 from datetime import datetime, timedelta
 
 TOKEN_PATH = "/iroh/oauth2/token"
@@ -7,153 +8,181 @@ AUTH_ME_PATH = "/auth/api-clients/me"
 API_HOST_NAME = "https://api.cta.eu.amp.cisco.com"
 APP_HOST_NAME = "https://cta.eu.amp.cisco.com"
 
-token_value = None
-token_validity = None
 
-customer_id = None
-
-
-def get_authorization(securex_host_name, secuerx_client_id, securex_client_password):
+class GtaAuth(AuthBase):
     """
-    Get HTTPs "Authorization" header value based on SecureX client credentials
-
-    :return: "Authorization" header value in form "<type> <credentials>". Type is now fixed (="Bearer")
-        because "token_type" in response is lower case (="bearer") and is not accepted in this form.
+    Class providing authorization mechanism to GTA API.
     """
-    global token_value
-    global token_validity
+    def __init__(self, securex_host_name, secuerx_client_id, securex_client_password):
+        self._securex_host_name = securex_host_name
+        self._secuerx_client_id = secuerx_client_id
+        self._securex_client_password = securex_client_password
 
-    if token_value is not None and token_validity is not None:
-        if datetime.now() < token_validity:
-            return token_value
+        self._token_value = None
+        self._token_validity = None
 
-    fetch_token_url = securex_host_name + TOKEN_PATH
+    def __call__(self, request):
+        if (self._token_value is None or self._token_validity is None) \
+                or (self._token_validity is not None and datetime.now() >= self._token_validity):
+            fetch_token_url = self._securex_host_name + TOKEN_PATH
 
-    token_response = requests.post(fetch_token_url,
-                                   data="grant_type=client_credentials",
-                                   headers={
-                                       "Accept": "application/json",
-                                       "Content-Type": "application/x-www-form-urlencoded"
-                                   },
-                                   auth=(secuerx_client_id, securex_client_password))
-    token_response_data = token_response.json()
+            token_response = requests.post(fetch_token_url,
+                                           data="grant_type=client_credentials",
+                                           headers={
+                                               "Accept": "application/json",
+                                               "Content-Type": "application/x-www-form-urlencoded"
+                                           },
+                                           auth=(self._secuerx_client_id, self._securex_client_password))
+            token_response_data = token_response.json()
 
-    # keep validity shorter - usually is 5-10 minutes, reduce it by 30 seconds to prevent longer request being rejected
-    token_validity = datetime.now() + timedelta(seconds=(token_response_data["expires_in"] - 30))
-    # cannot use directly "token_type" because it's not accepted ("bearer" -> must be "Bearer")
-    token_value = "Bearer " + token_response_data["access_token"]
+            # keep validity shorter - usually is 5-10 minutes, reduce it by 30 seconds to prevent request being rejected
+            self._token_validity = datetime.now() + timedelta(seconds=(token_response_data["expires_in"] - 30))
+            # cannot use directly "token_type" because it's not accepted ("bearer" -> must be "Bearer")
+            self._token_value = "Bearer " + token_response_data["access_token"]
 
-    return token_value
+        request.headers["Authorization"] = self._token_value
+        return request
 
 
-def get_customer_id(securex_host_name, secuerx_client_id, securex_client_password):
+class ApiClient:
     """
-    Get global threat alerts customer ID associated with SecureX client
-
-    :return: customer ID or None
+    GTA API client containing session instance (when instantiated) which is supposed to be used when accessing the API
+    including authorization.
     """
-    global customer_id
+    def __init__(self, securex_host_name, secuerx_client_id, securex_client_password, api_host_name=API_HOST_NAME, app_host_name=APP_HOST_NAME):
+        self._api_host_name = api_host_name
+        self._app_host_name = app_host_name
+        self._customer_id = None
+        self._api_session = requests.Session()
 
-    if customer_id is None:
-        response = requests.get(APP_HOST_NAME + AUTH_ME_PATH,
-                                headers={
-                                    "Authorization": get_authorization(
-                                        securex_host_name,
-                                        secuerx_client_id,
-                                        securex_client_password
-                                    ),
-                                    "Accept": "application/json"
-                                })
-        me_response = response.json()
-        customer_id = me_response["identity"]["customerId"]
-
-    return customer_id
-
-
-class CollectionIterator:
-    """
-    Object designed to help with processing of paged collections based on iterator pattern.
-    Both GET and POST collections are supported.
-    Params:
-    - collection_url_path (str) - URL path of collection we'd like to get items (without hostname and query parameters),
-      e.g., "/alert-management/customer/customerId/alerts"
-    - authorization_fn (str) - function able to generate "Authorization" header,
-      use "get_authorization" wrapped with credentials
-    - (optional) query_params (key: str - value: str) - query parameters in dictionary
-      e.g., { "size": "100" }
-    - (optional) cursor (str) - position of item (cursor) in collection where to continue iterating (usually cursor of last item from previous run)
-      e.g., "123456"
-    - (optional) request_body (dict) - do POST with this provided requestBody
-    """
-    def __init__(self, collection_url_path, authorization_fn, query_params=None, cursor=None, request_body=None):
-        # keep immutable these constructor parameters
-        self.collection_url_path = collection_url_path
-        self.authorization_fn = authorization_fn
-        self.query_params = query_params or {}
-        self.request_body = request_body
-
-        self.has_api_response = False
-        self.has_next_page = None
-        self.end_cursor = cursor
-        self.next_page_url = self.__build_next_page_url_from_variables(cursor)
-        self.current_page_items = []
-        self.current_page_items_pointer = 0
-
-    def has_next(self):
-        if not self.has_api_response:
-            self.__fetch_next_page()
-
-        return self.__has_current_page_items() or self.has_next_page
-
-    def next(self):
-        if not self.has_api_response \
-                or (not self.__has_current_page_items() and self.has_next_page):
-            self.__fetch_next_page()
-
-        if self.__has_current_page_items():
-            item = self.current_page_items[self.current_page_items_pointer]
-            self.current_page_items_pointer = self.current_page_items_pointer + 1
-            return item
-        else:
-            return None
-
-    def __fetch_next_page(self):
-        headers = {
-            "Authorization": self.authorization_fn(),
+        self._api_session.auth = GtaAuth(securex_host_name, secuerx_client_id, securex_client_password)
+        self._api_session.headers.update({
             "Accept": "application/json"
-        }
+        })
 
-        if self.request_body:
-            response = requests.post(API_HOST_NAME + self.next_page_url, headers=headers, json=self.request_body)
-        else:
-            response = requests.get(API_HOST_NAME + self.next_page_url, headers=headers)
+    def get_customer_id(self):
+        """
+        Get global threat alerts customer ID associated with SecureX client
 
-        data = response.json()
+        :return: customer ID
+        """
+        if self._customer_id is None:
+            response = self._api_session.get(self._app_host_name + AUTH_ME_PATH)
+            me_response = response.json()
+            self._customer_id = me_response["identity"]["customerId"]
 
-        self.current_page_items = data["items"]
-        self.has_api_response = True
-        self.current_page_items_pointer = 0
+        return self._customer_id
 
-        if "endCursor" in data["pageInfo"]:
-            self.end_cursor = data["pageInfo"]["endCursor"]
+    def create_collection_iterator(self, collection_url_path, query_params=None, cursor=None, request_body=None):
+        """
+        Creates new instance of CollectionIterator with current ApiClient reference
 
-        self.has_next_page = data["pageInfo"]["hasNextPage"]
-        self.next_page_url = data["pageInfo"]["next"]
+        :return: CollectionIterator instance
+        """
+        return ApiClient.CollectionIterator(
+            api_client=self,
+            collection_url_path=collection_url_path,
+            query_params=query_params,
+            cursor=cursor,
+            request_body=request_body)
 
-        if self.has_next_page and self.next_page_url is None:
-            self.next_page_url = self.__build_next_page_url_from_variables(self.end_cursor)
+    def api_session(self):
+        """
+        Returns current Session instance in ApiClient with authorization ("auth") set.
 
-    def __has_current_page_items(self):
-        return self.current_page_items_pointer < len(self.current_page_items)
+        :return: Session instance
+        """
+        return self._api_session
 
-    def __build_next_page_url_from_variables(self, end_cursor=None):
-        query_params_copy = self.query_params.copy()
-        if end_cursor:
-            query_params_copy["after"] = end_cursor
+    def api_host_name(self):
+        """
+        Returns current instance API host name.
 
-        if not query_params_copy:
-            return self.collection_url_path
+        :return: API host name string
+        """
+        return self._api_host_name
 
-        query_params_list = list(map(lambda kv: (kv[0] + "=" + str(kv[1] or "")), query_params_copy.items()))
-        query_params = "?" + "&".join(query_params_list)
-        return self.collection_url_path + query_params
+    class CollectionIterator:
+        """
+        Object designed to help with processing of paged collections based on iterator pattern.
+        Both GET and POST collections are supported.
+        Params:
+        - api_client (ApiClient) - initialized instance of ApiClient
+        - collection_url_path (str) - URL path of collection we'd like to get items (without hostname and query parameters),
+          e.g., "/alert-management/customer/customerId/alerts"
+        - (optional) query_params (key: str - value: str) - query parameters in dictionary
+          e.g., { "size": "100" }
+        - (optional) cursor (str) - position of item (cursor) in collection where to continue iterating (usually cursor of last item from previous run)
+          e.g., "123456"
+        - (optional) request_body (dict) - do POST with this provided requestBody
+        """
+
+        def __init__(self, api_client, collection_url_path, query_params=None, cursor=None, request_body=None):
+            # keep immutable these constructor parameters
+            self._api_client = api_client
+            self._collection_url_path = collection_url_path
+            self._query_params = query_params or {}
+            self._request_body = request_body
+
+            self._has_api_response = False
+            self._has_next_page = None
+            self._end_cursor = cursor
+            self._next_page_url = self.__build_next_page_url_from_variables(cursor)
+            self._current_page_items = []
+            self._current_page_items_pointer = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if not self._has_api_response \
+                    or (not self.__has_current_page_items() and self._has_next_page):
+                self.__fetch_next_page()
+
+            if self.__has_current_page_items():
+                item = self._current_page_items[self._current_page_items_pointer]
+                self._current_page_items_pointer = self._current_page_items_pointer + 1
+                return item
+            else:
+                raise StopIteration
+
+        next = __next__  # Python 2 support
+
+        def __fetch_next_page(self):
+            if self._request_body:
+                response = self._api_client.api_session().post(self._api_client.api_host_name() + self._next_page_url, json=self._request_body)
+            else:
+                response = self._api_client.api_session().get(self._api_client.api_host_name() + self._next_page_url)
+
+            data = response.json()
+
+            self._current_page_items = data["items"]
+            self._has_api_response = True
+            self._current_page_items_pointer = 0
+
+            if "endCursor" in data["pageInfo"]:
+                self._end_cursor = data["pageInfo"]["endCursor"]
+
+            self._has_next_page = data["pageInfo"]["hasNextPage"]
+            self._next_page_url = data["pageInfo"]["next"]
+
+            if self._has_next_page and self._next_page_url is None:
+                self._next_page_url = self.__build_next_page_url_from_variables(self._end_cursor)
+
+        def __has_current_page_items(self):
+            return self._current_page_items_pointer < len(self._current_page_items)
+
+        def __build_next_page_url_from_variables(self, end_cursor=None):
+            query_params_copy = self._query_params.copy()
+            if end_cursor:
+                query_params_copy["after"] = end_cursor
+
+            if not query_params_copy:
+                return self._collection_url_path
+
+            query_params_list = list(map(lambda kv: (kv[0] + "=" + str(kv[1] or "")), query_params_copy.items()))
+            query_params = "?" + "&".join(query_params_list)
+            return self._collection_url_path + query_params
+
+        def end_cursor(self):
+            return self._end_cursor

--- a/api_client.py
+++ b/api_client.py
@@ -2,9 +2,15 @@ import requests
 from datetime import datetime, timedelta
 
 TOKEN_PATH = "/iroh/oauth2/token"
+AUTH_ME_PATH = "/auth/api-clients/me"
+
+API_HOST_NAME = "https://api.cta.eu.amp.cisco.com"
+APP_HOST_NAME = "https://cta.eu.amp.cisco.com"
 
 token_value = None
 token_validity = None
+
+customer_id = None
 
 
 def get_authorization(securex_host_name, secuerx_client_id, securex_client_password):
@@ -38,3 +44,116 @@ def get_authorization(securex_host_name, secuerx_client_id, securex_client_passw
     token_value = "Bearer " + token_response_data["access_token"]
 
     return token_value
+
+
+def get_customer_id(securex_host_name, secuerx_client_id, securex_client_password):
+    """
+    Get global threat alerts customer ID associated with SecureX client
+
+    :return: customer ID or None
+    """
+    global customer_id
+
+    if customer_id is None:
+        response = requests.get(APP_HOST_NAME + AUTH_ME_PATH,
+                                headers={
+                                    "Authorization": get_authorization(
+                                        securex_host_name,
+                                        secuerx_client_id,
+                                        securex_client_password
+                                    ),
+                                    "Accept": "application/json"
+                                })
+        me_response = response.json()
+        customer_id = me_response["identity"]["customerId"]
+
+    return customer_id
+
+
+class CollectionIterator:
+    """
+    Object designed to help with processing of paged collections based on iterator pattern.
+    Both GET and POST collections are supported.
+    Params:
+    - collection_url_path (str) - URL path of collection we'd like to get items (without hostname and query parameters),
+      e.g., "/alert-management/customer/customerId/alerts"
+    - authorization_fn (str) - function able to generate "Authorization" header,
+      use "get_authorization" wrapped with credentials
+    - (optional) query_params (key: str - value: str) - query parameters in dictionary
+      e.g., { "size": "100" }
+    - (optional) cursor (str) - position of item (cursor) in collection where to continue iterating (usually cursor of last item from previous run)
+      e.g., "123456"
+    - (optional) request_body (dict) - do POST with this provided requestBody
+    """
+    def __init__(self, collection_url_path, authorization_fn, query_params=None, cursor=None, request_body=None):
+        # keep immutable these constructor parameters
+        self.collection_url_path = collection_url_path
+        self.authorization_fn = authorization_fn
+        self.query_params = query_params or {}
+        self.request_body = request_body
+
+        self.has_api_response = False
+        self.has_next_page = None
+        self.end_cursor = cursor
+        self.next_page_url = self.__build_next_page_url_from_variables(cursor)
+        self.current_page_items = []
+        self.current_page_items_pointer = 0
+
+    def has_next(self):
+        if not self.has_api_response:
+            self.__fetch_next_page()
+
+        return self.__has_current_page_items() or self.has_next_page
+
+    def next(self):
+        if not self.has_api_response \
+                or (not self.__has_current_page_items() and self.has_next_page):
+            self.__fetch_next_page()
+
+        if self.__has_current_page_items():
+            item = self.current_page_items[self.current_page_items_pointer]
+            self.current_page_items_pointer = self.current_page_items_pointer + 1
+            return item
+        else:
+            return None
+
+    def __fetch_next_page(self):
+        headers = {
+            "Authorization": self.authorization_fn(),
+            "Accept": "application/json"
+        }
+
+        if self.request_body:
+            response = requests.post(API_HOST_NAME + self.next_page_url, headers=headers, json=self.request_body)
+        else:
+            response = requests.get(API_HOST_NAME + self.next_page_url, headers=headers)
+
+        data = response.json()
+
+        self.current_page_items = data["items"]
+        self.has_api_response = True
+        self.current_page_items_pointer = 0
+
+        if "endCursor" in data["pageInfo"]:
+            self.end_cursor = data["pageInfo"]["endCursor"]
+
+        self.has_next_page = data["pageInfo"]["hasNextPage"]
+        self.next_page_url = data["pageInfo"]["next"]
+
+        if self.has_next_page and self.next_page_url is None:
+            self.next_page_url = self.__build_next_page_url_from_variables(self.end_cursor)
+
+    def __has_current_page_items(self):
+        return self.current_page_items_pointer < len(self.current_page_items)
+
+    def __build_next_page_url_from_variables(self, end_cursor=None):
+        query_params_copy = self.query_params.copy()
+        if end_cursor:
+            query_params_copy["after"] = end_cursor
+
+        if not query_params_copy:
+            return self.collection_url_path
+
+        query_params_list = list(map(lambda kv: (kv[0] + "=" + str(kv[1] or "")), query_params_copy.items()))
+        query_params = "?" + "&".join(query_params_list)
+        return self.collection_url_path + query_params

--- a/api_client.py
+++ b/api_client.py
@@ -11,7 +11,7 @@ APP_HOST_NAME = "https://cta.eu.amp.cisco.com"
 
 class GtaAuth(AuthBase):
     """
-    Class providing authorization mechanism to GTA API.
+    Class providing authorization mechanism to global threat alerts API.
     """
     def __init__(self, securex_host_name, secuerx_client_id, securex_client_password):
         self._securex_host_name = securex_host_name
@@ -46,7 +46,7 @@ class GtaAuth(AuthBase):
 
 class ApiClient:
     """
-    GTA API client containing session instance (when instantiated) which is supposed to be used when accessing the API
+    Global threat alerts API client containing session instance (when instantiated) which is supposed to be used when accessing the API
     including authorization.
     """
     def __init__(self, securex_host_name, secuerx_client_id, securex_client_password, api_host_name=API_HOST_NAME, app_host_name=APP_HOST_NAME):

--- a/get_all_alerts.py
+++ b/get_all_alerts.py
@@ -1,5 +1,5 @@
 import requests
-from api_client import get_authorization
+from api_client import GtaAuth
 
 CUSTOMER_ID = "YOUR_CUSTOMER_ID"
 
@@ -13,19 +13,16 @@ FETCH_ALERTS_URL = "/alert-management/customer/" + CUSTOMER_ID + "/alerts"
 
 def get_all_alerts():
     fetch_url = FETCH_ALERTS_URL
+    auth = GtaAuth(SECUREX_VISIBILITY_HOST_NAME, SECUREX_CLIENT_ID, SECUREX_CLIENT_PASSWORD)
     alerts = []
 
     while True:
         # request for page of item
         response = requests.get(API_HOST_NAME + fetch_url,
                                 headers={
-                                    "Authorization": get_authorization(
-                                        SECUREX_VISIBILITY_HOST_NAME,
-                                        SECUREX_CLIENT_ID,
-                                        SECUREX_CLIENT_PASSWORD
-                                    ),
                                     "Accept": "application/json"
-                                })
+                                },
+                                auth=auth)
         data = response.json()
 
         # collect all received items together, preserve order

--- a/get_security_annotations.py
+++ b/get_security_annotations.py
@@ -1,171 +1,117 @@
 #!/usr/bin/python
 
 from __future__ import print_function
-import requests
 import os
 import sys
 import datetime
 import json
-from api_client import get_authorization
-
-CUSTOMER_ID = "YOUR_CUSTOMER_ID"
+from api_client import get_customer_id, get_authorization, CollectionIterator
 
 SECUREX_CLIENT_ID = "YOUR_SECUREX_CLIENT_ID"
 SECUREX_CLIENT_PASSWORD = "YOUR_SECUREX_CLIENT_PASSWORD"
 SECUREX_VISIBILITY_HOST_NAME = "YOUR_SECUREX_VISIBILITY_HOST_NAME"
 
-PREVIOUS_EVENT_MODIFIED_AT_FILENAME = "previous_event_modified_at.txt"
+# Filename (including full path) to save cursor of then last processed event item.
+# It creates a new file, if the file does not exist otherwise truncates and over-write existing file.
+# Needs read/write access to the folder, e.g. "/home/splunk/events_end_cursor.txt"
+EVENTS_END_CURSOR_FILENAME = "/events_end_cursor.txt"
 
-API_HOST_NAME = "https://api.cta.eu.amp.cisco.com"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
-def parse_iso_datetime(iso_datetime):
-    try:
-        return datetime.datetime.strptime(iso_datetime, DATETIME_FORMAT)
-    except ValueError:
-        sys.stderr.write("Error: failed to parse datetime: \"" + iso_datetime + "\"\n")
+def customer_id():
+    return get_customer_id(
+        SECUREX_VISIBILITY_HOST_NAME,
+        SECUREX_CLIENT_ID,
+        SECUREX_CLIENT_PASSWORD)
 
 
-def read_max_event_modified_at():
-    if os.path.isfile(PREVIOUS_EVENT_MODIFIED_AT_FILENAME):
+def authorization():
+    return get_authorization(
+        SECUREX_VISIBILITY_HOST_NAME,
+        SECUREX_CLIENT_ID,
+        SECUREX_CLIENT_PASSWORD)
+
+
+def read_events_end_cursor():
+    if os.path.isfile(EVENTS_END_CURSOR_FILENAME):
         try:
-            previous_event_modified_at_file = open(PREVIOUS_EVENT_MODIFIED_AT_FILENAME, "r")
-            previous_event_modified_at = parse_iso_datetime(previous_event_modified_at_file.readline())
-            previous_event_modified_at_file.close()
-            return previous_event_modified_at
+            with open(EVENTS_END_CURSOR_FILENAME, "r") as events_end_cursor_file:
+                events_end_cursor = events_end_cursor_file.readline()
+                return events_end_cursor
         except IOError:
-            sys.stderr.write("Error: failed to read max event modifiedAt: " + PREVIOUS_EVENT_MODIFIED_AT_FILENAME + "\n")
+            sys.stderr.write("Error: failed to read events end cursor: " + EVENTS_END_CURSOR_FILENAME + "\n")
             sys.exit(1)
     else:
-        return datetime.datetime.fromtimestamp(0)
+        return None
 
 
-def write_max_event_modified_at(max_event_modified_at):
+def write_events_end_cursor(events_end_cursor):
     try:
-        previous_event_modified_at_file = open(PREVIOUS_EVENT_MODIFIED_AT_FILENAME, "w")
-        previous_event_modified_at_file.write(max_event_modified_at.strftime(DATETIME_FORMAT))
-        previous_event_modified_at_file.close()
-
+        with open(EVENTS_END_CURSOR_FILENAME, "w") as events_end_cursor_file:
+            events_end_cursor_file.write(events_end_cursor)
     except IOError:
-        sys.stderr.write("Error writing max event modifiedAt: " + PREVIOUS_EVENT_MODIFIED_AT_FILENAME + "\n")
+        sys.stderr.write("Error writing events end cursor: " + EVENTS_END_CURSOR_FILENAME + "\n")
         sys.exit(2)
 
 
-class CollectionIterator:
-
-    def __init__(self, collection_url):
-        self.has_api_response = False
-        self.has_next_page = None
-        self.next_page_url = collection_url
-        self.current_page_items = []
-        self.current_page_items_pointer = 0
-
-    def has_next(self):
-        if not self.has_api_response:
-            self.__fetch_next_page()
-
-        return self.__has_current_page_items() or self.has_next_page
-
-    def next(self):
-        if not self.has_api_response \
-                or (not self.__has_current_page_items() and self.has_next_page):
-            self.__fetch_next_page()
-
-        if self.__has_current_page_items():
-            item = self.current_page_items[self.current_page_items_pointer]
-            self.current_page_items_pointer = self.current_page_items_pointer + 1
-            return item
-        else:
-            return None
-
-    def __fetch_next_page(self):
-        response = requests.get(API_HOST_NAME + self.next_page_url,
-                                headers={
-                                    "Authorization": get_authorization(
-                                        SECUREX_VISIBILITY_HOST_NAME,
-                                        SECUREX_CLIENT_ID,
-                                        SECUREX_CLIENT_PASSWORD
-                                    ),
-                                    "Accept": "application/json"
-                                })
-        data = response.json()
-        self.has_next_page = data["pageInfo"]["hasNextPage"]
-        self.next_page_url = data["pageInfo"]["next"]
-        self.current_page_items = data["items"]
-        self.current_page_items_pointer = 0
-        self.has_api_response = True
-
-    def __has_current_page_items(self):
-        return self.current_page_items_pointer < len(self.current_page_items)
+def build_alerts_search_url():
+    return "/alert-management/customer/" + customer_id() + "/alerts/search"
 
 
-def get_asset(asset_id):
-    response = requests.get(API_HOST_NAME + build_asset_url(asset_id),
-                            headers={
-                                "Authorization": get_authorization(
-                                    SECUREX_VISIBILITY_HOST_NAME,
-                                    SECUREX_CLIENT_ID,
-                                    SECUREX_CLIENT_PASSWORD
-                                ),
-                                "Accept": "application/json"
-                            })
-    return response.json()
-
-def get_threat_intel(threat_intel_id):
-    response = requests.get(API_HOST_NAME + build_threat_intel_url(threat_intel_id),
-                            headers={
-                                "Authorization": get_authorization(
-                                    SECUREX_VISIBILITY_HOST_NAME,
-                                    SECUREX_CLIENT_ID,
-                                    SECUREX_CLIENT_PASSWORD
-                                ),
-                                "Accept": "application/json"
-                            })
-    return response.json()
+def build_assets_search_url():
+    return "/asset-management/customer/" + customer_id() + "/assets/search"
 
 
-def build_alert_threat_detections_url(alert_id):
-    return "/alert-management/customer/" + CUSTOMER_ID + "/alerts/" + alert_id + "/threat-detections"
+def build_threat_intel_url():
+    return "/threat-catalog/records"
 
 
-def build_threat_detection_convicting_events_url(threat_detection_id):
-    return "/threat-detection/customer/" + CUSTOMER_ID + "/threat-detections/" + threat_detection_id + "/events/convicting"
+def build_search_threat_detection_with_alert_id_url():
+    return "/alert-management/customer/" \
+           + customer_id() \
+           + "/enriched-threat-detections-with-alert-ids/search"
 
 
-def build_threat_detection_contextual_events_url(threat_detection_id):
-    return "/threat-detection/customer/" + CUSTOMER_ID + "/threat-detections/" + threat_detection_id + "/events/contextual"
+def build_event_with_threat_detections_ids_url():
+    return "/threat-detection/customer/" \
+           + customer_id() \
+           + "/enriched-events-with-threat-detection-ids"
 
 
-def build_asset_url(asset_id):
-    return "/asset-management/customer/" + CUSTOMER_ID + "/assets/" + asset_id
-
-
-def build_threat_intel_url(threat_intel_id):
-    return "/threat-catalog/records/" + threat_intel_id
-
-
-def log_event_attributes(alert, threat_intel_record, asset, threat_detection, event):
+def log_event_attributes(event, affected_asset, threat_detection=None, alert=None, threat_intel_record=None):
     row = {
         "indexTime": datetime.datetime.now().strftime(DATETIME_FORMAT),
-        "alertId": alert["id"],
-        "alertState": alert["state"],
-        "assumedOwner": asset["assumedOwner"],
-        "risk": alert["risk"],
-        "threatTitle": threat_intel_record["title"],
-        "threatCategory": threat_intel_record["category"],
-        "threatSubCategory": threat_intel_record["subcategory"],
-        "severity": threat_intel_record["severity"],
-        "affectedAssetId": threat_detection["affectedAssetId"],
-        "threatDetectionId": threat_detection["id"],
-        "confidence": threat_detection["confidence"],
         "eventId": event["id"],
         "eventDetectedAt": event["detectedAt"],
         "eventModifiedAt": event["modifiedAt"],
         "securityEventTypeId": event["securityEventTypeId"],
         "eventTitle": event["title"],
         "eventSubtitle": event["subtitle"],
+        "assumedOwner": affected_asset["assumedOwner"],
     }
+
+    if alert:
+        row.update({
+            "alertId": alert["id"],
+            "alertState": alert["state"],
+            "risk": alert["risk"],
+        })
+
+    if threat_intel_record:
+        row.update({
+            "threatTitle": threat_intel_record["title"],
+            "threatCategory": threat_intel_record["category"],
+            "threatSubCategory": threat_intel_record["subcategory"],
+            "severity": threat_intel_record["severity"],
+        })
+
+    if threat_detection:
+        row.update({
+            "affectedAssetId": threat_detection["affectedAssetId"],
+            "threatDetectionId": threat_detection["id"],
+            "confidence": threat_detection["confidence"],
+        })
 
     if event["securityAnnotation"]:
         row.update({
@@ -176,50 +122,140 @@ def log_event_attributes(alert, threat_intel_record, asset, threat_detection, ev
     print(json.dumps(row))
 
 
-def process_events(alert, threat_detection, threat_intel_record, asset, events_iterator, previous_max_event_modified_at, max_event_modified_at):
+def main():
+    # read stored cursor of last security event item from previous script run (if any)
+    # to process only new or modified events in current script run
+    previous_events_end_cursor = read_events_end_cursor()
+
+    # USE BULK LOADING RESOURCES ON API TO PRELOAD EVENTS AND IMPORTANT REFERRED OBJECTS
+
+    # remember events
+    events = []
+    # cached contextual objects - alerts, threat detections, threat intel records, assets
+    cached_context_objects = {}
+
+    threat_detection_ids = []
+    affected_asset_ids = []
+
+    # iterate over all security events sorted by unique modification sequence number ensuring no event is missed
+    events_iterator = CollectionIterator(
+        collection_url_path=build_event_with_threat_detections_ids_url(),
+        authorization_fn=authorization,
+        query_params={
+            "sort": "modificationSequenceNumber",
+        },
+        cursor=previous_events_end_cursor
+    )
+    # remember events and get ids of related object (threat detections and assets) to "bulk load" them
     while events_iterator.has_next():
         event = events_iterator.next()
+        events.append(event)
+        threat_detection_ids.extend(event["threatDetectionIds"])
+        affected_asset_ids.append(event["affectedAssetId"])
 
-        modified_at_event_datetime = parse_iso_datetime(event["modifiedAt"])
-        if modified_at_event_datetime > previous_max_event_modified_at:
-            log_event_attributes(alert, threat_intel_record, asset, threat_detection, event)
+    # bulk load threat detections by their ids
+    threat_detections_iterator = CollectionIterator(
+        collection_url_path=build_search_threat_detection_with_alert_id_url(),
+        authorization_fn=authorization,
+        request_body={
+            "filter": {
+                "threatDetectionIds": list(set(threat_detection_ids))
+            }
+        }
+    )
 
-            if modified_at_event_datetime > max_event_modified_at:
-                max_event_modified_at = modified_at_event_datetime
+    alert_ids = []
+    threat_intel_record_ids = []
 
-    return max_event_modified_at
+    # keep threat detections in "cached_context_objects" and extract IDs of alerts and threat intel records
+    while threat_detections_iterator.has_next():
+        threat_detection = threat_detections_iterator.next()
+        cached_context_objects[threat_detection["id"]] = threat_detection
+        alert_ids.extend(threat_detection["alertIds"])
+        threat_intel_record_ids.append(threat_detection["threatIntelRecordId"])
 
+    # bulk load assets by their ids
+    affected_asset_iterator = CollectionIterator(
+        collection_url_path=build_assets_search_url(),
+        authorization_fn=authorization,
+        request_body={
+            "filter": {
+                "assetId": list(set(affected_asset_ids))
+            }
+        }
+    )
 
-def main():
-    # get maximal "modifiedAt" from all processed Sightings stored after previous run
-    previous_max_event_modified_at = read_max_event_modified_at()
-    # variable holding "modifiedAt" maximum for all Sightings currently processed
-    max_event_modified_at = previous_max_event_modified_at
+    # keep assets in "cached_context_objects"
+    while affected_asset_iterator.has_next():
+        affected_asset = affected_asset_iterator.next()
+        cached_context_objects[affected_asset["id"]] = affected_asset
 
-    alerts_iterator = CollectionIterator("/alert-management/customer/" + CUSTOMER_ID + "/alerts")
+    # bulk load alerts
+    alerts_iterator = CollectionIterator(
+        collection_url_path=build_alerts_search_url(),
+        authorization_fn=authorization,
+        request_body={
+            "filter": {
+                "alertIds": list(set(alert_ids))
+            }
+        }
+    )
 
-    # iterate through all alerts
+    # keep alerts in "cached_context_objects"
     while alerts_iterator.has_next():
         alert = alerts_iterator.next()
+        cached_context_objects[alert["id"]] = alert
 
-        threat_detections_iterator = CollectionIterator(build_alert_threat_detections_url(alert["id"]))
+    # bulk load threat intelligence records
+    threat_intel_records_iterator = CollectionIterator(
+        collection_url_path=build_threat_intel_url(),
+        authorization_fn=authorization,
+        request_body={
+            "filter": {
+                "threatIntelRecordId": list(set(threat_intel_record_ids))
+            }
+        }
+    )
 
-        # iterate through all threat_detections
-        while threat_detections_iterator.has_next():
-            threat_detection = threat_detections_iterator.next()
-            asset = get_asset(threat_detection["affectedAssetId"])
-            threat_intel_record = get_threat_intel(threat_detection["threatIntelRecordId"])
+    # keep threat intelligence records in "cached_context_objects"
+    while threat_intel_records_iterator.has_next():
+        threat_intel_record = threat_intel_records_iterator.next()
+        cached_context_objects[threat_intel_record["id"]] = threat_intel_record
 
-            # iterate through all convicting events
-            convicting_events_iterator = CollectionIterator(build_threat_detection_convicting_events_url(threat_detection["id"]))
-            max_event_modified_at = process_events(alert, threat_detection, threat_intel_record, asset, convicting_events_iterator, previous_max_event_modified_at, max_event_modified_at)
+    # PROCESS EVENTS AND OTHER CONTEXTUAL OBJECTS
 
-            # iterate through all contextual events
-            contextual_events_iterator = CollectionIterator(build_threat_detection_contextual_events_url(threat_detection["id"]))
-            max_event_modified_at = process_events(alert, threat_detection, threat_intel_record, asset, contextual_events_iterator, previous_max_event_modified_at, max_event_modified_at)
+    # start with events, get contextual objects for each event from cached_context_objects and log them together
+    for event in events:
+        # get affected asset referred by event
+        affected_asset = cached_context_objects[event["affectedAssetId"]]
 
-    # persist maximal "modifiedAt" for next run
-    write_max_event_modified_at(max_event_modified_at)
+        # get IDs references to threat detections from event (usually one)
+        threat_detection_ids = event["threatDetectionIds"]
+
+        # process all possible threat detections
+        if len(threat_detection_ids) > 0:
+            # process event with threat detections (called "convicting" security event)
+            for threat_detection_id in threat_detection_ids:
+                # get parent objects to event - threat detections and alert
+                # and also threat intel record from threat-catalog bounded context
+                threat_detection_with_alert_ids = cached_context_objects[threat_detection_id]
+                threat_intel_record = cached_context_objects[threat_detection_with_alert_ids["threatIntelRecordId"]]
+
+                # get IDs references to alerts (usually one)
+                alert_ids = threat_detection_with_alert_ids["alertIds"]
+                for alert_id in alert_ids:
+                    alert = cached_context_objects[alert_id]
+
+                    # log event with related objects - alert, threat detection, threat intel record
+                    log_event_attributes(event, affected_asset, threat_detection_with_alert_ids, alert, threat_intel_record)
+        else:
+            # process event without threat detections (called "contextual" security event)
+            # log event just with affected_asset
+            log_event_attributes(event, affected_asset)
+
+    # store events end_cursor for next script run
+    if events_iterator.end_cursor:
+        write_events_end_cursor(events_iterator.end_cursor)
 
 
 main()


### PR DESCRIPTION
- using modification sequence number order on events ensuring
  all new/changes events are processed. Needed to change
  traversal order - now script is going from bottom (events) to
  top (alerts).

- taking customer ID from API, it's enough to relpace
  just SecureX parameter